### PR TITLE
Fix macOS platform build error

### DIFF
--- a/miscellaneous.go
+++ b/miscellaneous.go
@@ -31,7 +31,7 @@ func ErrorName(err ErrorCode) string {
 
 // StrError implements the libusb_strerror function.
 func StrError(err ErrorCode) string {
-	return C.GoString(C.libusb_strerror(int32(err)))
+	return C.GoString(C.libusb_strerror(C.int(err)))
 }
 
 // SetLocale sets the locale for libusb errors.


### PR DESCRIPTION
```
.go/pkg/mod/github.com/gotmc/libusb@v1.0.22/miscellaneous.go:34:43: cannot use int32(err) (type int32) as type _Ctype_int in argument to _Cfunc_libusb_strerror
```

os: Darwin x64 20.2.0 macOS 11.1
Golang: 1.15.5