### PR TITLE
Add missing Interval value in endpointDescriptor

### DIFF
--- a/device.go
+++ b/device.go
@@ -233,6 +233,7 @@ func (dev *Device) ActiveConfigDescriptor() (*ConfigDescriptor, error) {
 					EndpointAddress: endpointAddress(libusbEndpointDescriptor.bEndpointAddress),
 					Attributes:      endpointAttributes(libusbEndpointDescriptor.bmAttributes),
 					MaxPacketSize:   uint16(libusbEndpointDescriptor.wMaxPacketSize),
+					Interval:        uint8(libusbEndpointDescriptor.bInterval),
 				}
 				endpointDescriptors = append(endpointDescriptors, &endpointDescriptor)
 			}


### PR DESCRIPTION
The Interval value is always empty in endpointDescriptor and not retrieve in the loop.
This PR add this missing value (these value can be used to detect the polling rate of device)
