### PR TITLE
Ignore LIBUSB_ERROR_INTERRUPTED in handleEvents to avoid unnecessary log spam

### DIFF
--- a/hotplug.go
+++ b/hotplug.go
@@ -211,6 +211,9 @@ func (storage *HotplugCallbackStorage) handleEvents(libCtx *C.libusb_context) {
 		default:
 		}
 		if errno := C.libusb_handle_events_completed(libCtx, nil); errno < 0 {
+			if ErrorCode(errno) == ErrorInterrupted {
+        		continue // ignore harmless EINTR
+    		}
 			log.Printf("handle_events error: %s", ErrorCode(errno))
 		}
 	}


### PR DESCRIPTION
This PR updates the handleEvents loop to ignore harmless LIBUSB_ERROR_INTERRUPTED (EINTR) errors returned by libusb_handle_events_completed.


**Background**

LIBUSB_ERROR_INTERRUPTED occurs when a system call is interrupted by a signal. This is a normal and expected condition and not a fatal error. However, the current implementation logs this at every occurrence, which results in excessive log spam in long-running applications (e.g., daemons or agents using USB hotplug)

**Example logs before this change:**

2025/09/19 12:53:48 handle_events error: LIBUSB_ERROR_INTERRUPTED: System call interrupted (perhaps due to signal)
2025/09/19 13:00:48 handle_events error: LIBUSB_ERROR_INTERRUPTED: System call interrupted (perhaps due to signal)
...


**Change**

**The fix adds a simple conditional check:**

  if errno := C.libusb_handle_events_completed(libCtx, nil); errno < 0 {
      if ErrorCode(errno) == ErrorInterrupted {
          // Ignore harmless EINTR instead of spamming logs
          continue
      }
      log.Printf("handle_events error: %s", ErrorCode(errno))
  }

**Benefits**

Keeps logs clean by ignoring expected EINTR interruptions.

All other error conditions continue to be logged normally.

Improves usability for production services without changing external behavior.